### PR TITLE
check all windows versions

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -148,7 +148,7 @@ def update_version(version):
 
         # rename file
         extracted_name = "chromedriver"
-        if p == "win":
+        if p in ["win", "win32", "win64"]:
             extracted_name += ".exe"
             filename += ".exe"
 


### PR DESCRIPTION
Currently, the GitHub actions fail to compile. This resolves renaming the **chromedriver** downloadable to the appropriate platform for windows