### PR TITLE
publish other channels as prereleases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   build-and-deploy:
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: ["Stable", "Beta", "Dev", "Canary"]
     runs-on: ubuntu-latest
     steps:
       -
@@ -20,7 +24,7 @@ jobs:
         run: pip3 install -r requirements.txt
       -
         name: Search for new version
-        run: python3 updater.py
+        run: python3 updater.py ${{ matrix.channel }}
       -
         name: Install pypa/build
         # only run if we found a new version

--- a/updater.py
+++ b/updater.py
@@ -43,7 +43,7 @@ def download_binaries(channel):
             dest += ".exe"
 
         print("extracting zip file")
-        z.extract(origin)
+        z.extract(origin.replace("\\", "/"))
 
         print("moving file to correct folder")
         os.rename(origin, dest)


### PR DESCRIPTION
fixes #42 

as far as i'm aware to publish a prerelease the version number needs to match [this format](https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers), so i had to give each channel a pypi-compatible suffix:

|chromedriver channel|pypi channel|
|-|-|
|Beta|`"b"`|
|Dev|`"a"`|
|Canary|`".dev"`|